### PR TITLE
correct macOS binary release signing

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -4,13 +4,13 @@ on:
 
 jobs:
   releases-matrix:
-    name: Release Grab binary
-    runs-on: ubuntu-latest
+    name: Release Grab binary for macOs
+    runs-on: macos-latest
     strategy:
       matrix:
         # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64
-        goos: [linux, windows]
-        goarch: ["386", amd64]
+        goos: [darwin]
+        goarch: [amd64]
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
The Go binaries generated on Linux don't work out of the box on macOS
due to code signing. We instead build the macOS release on macOS.