### PR TITLE
remove explicit installation of test dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,6 @@ jobs:
           go-version: ${{ steps.go_versions.outputs.go_version }}
         id: go
 
-      - name: Install test dependencies
-        run: |
-          go test -i -race .
       - name: Run tests
         run: |
           go test -race .


### PR DESCRIPTION
The `-i` flag is no longer supported on `go test` (and isn't really necessary anymore).