### PR TITLE
support .config on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Grab can be configured with the `GRAB_HOME` environment variable and further
 configurations (including that setting) can be set with a TOML config file at
 `grab/config.toml` inside your platforms configuration directory.
 
-(On Windows, that's in `%AppData%`. On MacOS, that's `$HOME/Library/Application
-Support`. And Linux and BSD, that's `$XDG_CONFIG_HOME` or `$HOME/.config/` if
-that's not set.)
+(On Windows, that's in `%AppData%`. On macOS, that's `$HOME/.config/` or
+`$HOME/Library/Application Support/grab` if `.config/grab/config.toml` doesn't exist.
+On Linux and BSD, that's `$XDG_CONFIG_HOME` or `$HOME/.config/` if that's not
+set.)
 
 The config settings in `config.toml` and `config.toml` itself are all optional.
 

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -17,6 +18,21 @@ type config struct {
 }
 
 func loadConfig() (config, error) {
+	// On macOS, check $HOME/.config/grab/config.toml first before falling
+	// back to the native Library/Application Support directory.
+	if runtime.GOOS == "darwin" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return config{}, err
+		}
+		// Duplicating the appending of grab to the config dir because this is
+		// the only platform we have a fallback on.
+		xdgConfig := filepath.Join(homeDir, ".config", "grab", "config.toml")
+		if _, err := os.Stat(xdgConfig); err == nil {
+			return loadConfigFrom(filepath.Join(homeDir, ".config"))
+		}
+	}
+
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		return config{}, err


### PR DESCRIPTION
Plenty of macOS tools (like gh, op, etc) use the .config directory to
store their configuration. This change adds support for looking in that
directory for config files on macOS on top of ~/Library/Application
Support/grab.
