### PR TITLE
add support for preferring SSH for specified hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,17 @@ configurations (including that setting) can be set with a TOML config file at
 On Linux and BSD, that's `$XDG_CONFIG_HOME` or `$HOME/.config/` if that's not
 set.)
 
-The config settings in `config.toml` and `config.toml` itself are all optional.
+The config settings in `config.toml` and the existenc of `config.toml` itself
+are optional.
 
 ```toml
 home = "/home/user/src" # prefer the env var GRAB_HOME if shell-variables are needed
+ssh_preferred_hosts = ["github.com", "gitlab.com"]
 ```
 
 - **`home`**: The directory to download repos into. Equivalent to `GRAB_HOME`.
+- **`ssh_preferred_hosts`**: A list of hosts for which git clone URLs should be rewritten
+  from HTTPS to SSH (e.g. `git@github.com:user/repo.git`).
 
-Environment variables override config file values:
-
-- `GRAB_HOME` overrides `home`.
+The environment variable `GRAB_HOME` overrides `home` and `GRAB_HOME` is
+preferred if you need shell variables in it (like `~` or `$HOME`).

--- a/config.go
+++ b/config.go
@@ -14,7 +14,8 @@ import (
 )
 
 type config struct {
-	Home string `toml:"home"`
+	Home              string   `toml:"home"`
+	SSHPreferredHosts []string `toml:"ssh_preferred_hosts"`
 }
 
 func loadConfig() (config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,9 @@ func TestLoadConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		if len(cfg.SSHPreferredHosts) != 0 {
+			t.Errorf("expected no ssh hosts, got %v", cfg.SSHPreferredHosts)
+		}
 		// Home should default to ~/src.
 		homeDir, _ := os.UserHomeDir()
 		want := filepath.Join(homeDir, "src")
@@ -30,7 +33,7 @@ func TestLoadConfig(t *testing.T) {
 		dir := t.TempDir()
 		grabDir := filepath.Join(dir, "grab")
 		os.MkdirAll(grabDir, 0755)
-		os.WriteFile(filepath.Join(grabDir, "config.toml"), []byte("home = \"/tmp/src\"\n"), 0644)
+		os.WriteFile(filepath.Join(grabDir, "config.toml"), []byte("home = \"/tmp/src\"\nssh_preferred_hosts = [\"github.com\"]\n"), 0644)
 		t.Setenv("GRAB_HOME", "")
 
 		cfg, err := loadConfigFrom(dir)
@@ -40,13 +43,16 @@ func TestLoadConfig(t *testing.T) {
 		if cfg.Home != "/tmp/src" {
 			t.Errorf("Home = %q, want /tmp/src", cfg.Home)
 		}
+		if len(cfg.SSHPreferredHosts) != 1 || cfg.SSHPreferredHosts[0] != "github.com" {
+			t.Errorf("SSHHosts = %v, want [github.com]", cfg.SSHPreferredHosts)
+		}
 	})
 
-	t.Run("env vars override config file", func(t *testing.T) {
+	t.Run("env var overrides home", func(t *testing.T) {
 		dir := t.TempDir()
 		grabDir := filepath.Join(dir, "grab")
 		os.MkdirAll(grabDir, 0755)
-		os.WriteFile(filepath.Join(grabDir, "config.toml"), []byte("home = \"/tmp/src\"\n"), 0644)
+		os.WriteFile(filepath.Join(grabDir, "config.toml"), []byte("home = \"/tmp/src\"\nssh_preferred_hosts = [\"github.com\"]\n"), 0644)
 		t.Setenv("GRAB_HOME", "/override/src")
 
 		cfg, err := loadConfigFrom(dir)
@@ -55,6 +61,9 @@ func TestLoadConfig(t *testing.T) {
 		}
 		if cfg.Home != "/override/src" {
 			t.Errorf("Home = %q, want /override/src", cfg.Home)
+		}
+		if len(cfg.SSHPreferredHosts) != 1 || cfg.SSHPreferredHosts[0] != "github.com" {
+			t.Errorf("SSHHosts = %v, want [github.com]", cfg.SSHPreferredHosts)
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -41,9 +41,14 @@ func main() {
 		log.Fatalf("unable to figure out the repo root from the given url: %s", err)
 	}
 
+	repo := repoRoot.Repo
+	if repoRoot.VCS.Cmd == "git" {
+		repo = rewriteToSSH(repo, cfg.SSHPreferredHosts)
+	}
+
 	root := filepath.Join(cfg.Home, repoRoot.Root)
-	err = repoRoot.VCS.Create(root, repoRoot.Repo)
+	err = repoRoot.VCS.Create(root, repo)
 	if err != nil {
-		log.Fatalf("unable to download %#v into %#v", repoRoot.Repo, root)
+		log.Fatalf("unable to download %#v into %#v", repo, root)
 	}
 }

--- a/ssh.go
+++ b/ssh.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Jeffrey M Hodges.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// rewriteToSSH rewrites an HTTPS repository URL to its SSH equivalent
+// (git@host:path.git) if the URL's host is in sshHosts.
+func rewriteToSSH(repoURL string, sshHosts []string) string {
+	if len(sshHosts) == 0 {
+		return repoURL
+	}
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return repoURL
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return repoURL
+	}
+	host := u.Hostname()
+	for _, h := range sshHosts {
+		if strings.EqualFold(host, h) {
+			path := strings.TrimPrefix(u.Path, "/")
+			if !strings.HasSuffix(path, ".git") {
+				path += ".git"
+			}
+			return "git@" + host + ":" + path
+		}
+	}
+	return repoURL
+}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Jeffrey M Hodges.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestRewriteToSSH(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoURL  string
+		sshHosts []string
+		want     string
+	}{
+		{
+			name:     "github https to ssh",
+			repoURL:  "https://github.com/jmhodges/grab",
+			sshHosts: []string{"github.com"},
+			want:     "git@github.com:jmhodges/grab.git",
+		},
+		{
+			name:     "github https with .git suffix",
+			repoURL:  "https://github.com/jmhodges/grab.git",
+			sshHosts: []string{"github.com"},
+			want:     "git@github.com:jmhodges/grab.git",
+		},
+		{
+			name:     "non-matching host unchanged",
+			repoURL:  "https://gitlab.com/user/repo",
+			sshHosts: []string{"github.com"},
+			want:     "https://gitlab.com/user/repo",
+		},
+		{
+			name:     "empty ssh hosts unchanged",
+			repoURL:  "https://github.com/jmhodges/grab",
+			sshHosts: nil,
+			want:     "https://github.com/jmhodges/grab",
+		},
+		{
+			name:     "non-https scheme unchanged",
+			repoURL:  "git://github.com/jmhodges/grab",
+			sshHosts: []string{"github.com"},
+			want:     "git://github.com/jmhodges/grab",
+		},
+		{
+			name:     "http also rewritten",
+			repoURL:  "http://github.com/jmhodges/grab",
+			sshHosts: []string{"github.com"},
+			want:     "git@github.com:jmhodges/grab.git",
+		},
+		{
+			name:     "multiple ssh hosts",
+			repoURL:  "https://gitlab.com/user/repo",
+			sshHosts: []string{"github.com", "gitlab.com"},
+			want:     "git@gitlab.com:user/repo.git",
+		},
+		{
+			name:     "case insensitive host match",
+			repoURL:  "https://GitHub.com/jmhodges/grab",
+			sshHosts: []string{"github.com"},
+			want:     "git@GitHub.com:jmhodges/grab.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteToSSH(tt.repoURL, tt.sshHosts)
+			if got != tt.want {
+				t.Errorf("rewriteToSSH(%q, %v) = %q, want %q", tt.repoURL, tt.sshHosts, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new ssh_preferred_hosts config option that rewrites HTTPS git
clone URLs to SSH (git@host:path.git) for specified hosts. This lets
users who prefer SSH authentication (e.g. with GitHub or GitLab) use
grab without needing to pass SSH URLs manually. Includes tests for the
URL rewriting logic and updated config loading/tests
