### PR TITLE
Pin GHA action versions to commit SHAs with version comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read Go versions
         run: echo "##[set-output name=go_version;]$(cat .github/versions/go)"
         id: go_versions
 
       - name: Set up Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ steps.go_versions.outputs.go_version }}
         id: go


### PR DESCRIPTION
- actions/checkout@v7 → 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 (v7.0.0)
- actions/setup-go@v6.4.0 → 4a3601121dd01d1626a1e23e37211e3254c1c06c (v6.4.0)